### PR TITLE
docs: condition on step if pull_request

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ jobs:
 
 See examples in [opened PR](https://github.com/thollander/actions-comment-pull-request/pulls) !
 
-:information_source: : Add `if: ${{ github.event_name == 'pull_request' }}` to this Action's step if the workflow is also trigger by events other than `pull_request` events.
+:information_source: : Add `if: ${{ github.event_name == 'pull_request' }}` to this Action's step if your workflow is not only triggered by a `pull_request` event. It will ensure that you don't throw an error on this step. 
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ jobs:
 
 See examples in [opened PR](https://github.com/thollander/actions-comment-pull-request/pulls) !
 
-:information_source: : Make sure to listen to `pull_request` events. 
-Otherwise, it will not be able to comment the PR and you'll have an error. 
+:information_source: : Add `if: ${{ github.event_name == 'pull_request' }}` to this Action's step if the workflow is also trigger by events other than `pull_request` events.
 
 ## Contributing
 


### PR DESCRIPTION
Proposal to suggest to users to make the comment step optional by checking the `github.event_name` in order to use it in workflows that run for other events as well. I think this is a better solution to document than asking users to not use this Action in other context.

If you have suggestions for how to better document this, feel free to propose or edit directly :slightly_smiling_face: 