### PR TITLE
fix: manage absolute path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: (BEFORE) Setup test cases
+        run: echo '**Content of file referenced with absolute path**' > /tmp/foobar.txt
+
       - name: Comment PR with message
         uses: ./
         with:
@@ -28,9 +31,20 @@ jobs:
           reactions: eyes, rocket
           mode: recreate
 
+      - name: Comment PR with file (absolute path)
+        uses: ./
+        with:
+          filePath: /tmp/foobar.txt
+          comment_tag: nrt_file_absolute
+          reactions: eyes, rocket
+          mode: recreate
+
       - name: Do not comment PR if not exists
         uses: ./
         with:
           message: Should not be printed
           comment_tag: nrt_create_if_not_exists
           create_if_not_exists: false
+
+      - name: (AFTER) Setup test cases
+        run: rm /tmp/foobar.txt

--- a/lib/index.js
+++ b/lib/index.js
@@ -9539,7 +9539,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path_1 = __importDefault(__nccwpck_require__(1017));
 const fs_1 = __importDefault(__nccwpck_require__(7147));
 const github = __importStar(__nccwpck_require__(5438));
 const core = __importStar(__nccwpck_require__(2186));
@@ -9560,15 +9559,8 @@ async function run() {
             return;
         }
         let content = message;
-        let _filePath;
         if (!message && filePath) {
-            const { GITHUB_WORKSPACE } = process.env;
-            if (!GITHUB_WORKSPACE) {
-                core.setFailed('"GITHUB_WORKSPACE" env variable is not defined.');
-                return;
-            }
-            _filePath = path_1.default.join(GITHUB_WORKSPACE, filePath);
-            content = fs_1.default.readFileSync(_filePath, 'utf8');
+            content = fs_1.default.readFileSync(filePath, 'utf8');
         }
         const context = github.context;
         const issue_number = parseInt(pr_number) || context.payload.pull_request?.number || context.payload.issue?.number;

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,17 +25,8 @@ async function run() {
     }
 
     let content: string = message;
-    let _filePath: string;
     if (!message && filePath) {
-      const { GITHUB_WORKSPACE } = process.env;
-
-      if (!GITHUB_WORKSPACE) {
-        core.setFailed('"GITHUB_WORKSPACE" env variable is not defined.');
-        return;
-      }
-
-      _filePath = path.join(GITHUB_WORKSPACE, filePath);
-      content = fs.readFileSync(_filePath, 'utf8');
+      content = fs.readFileSync(filePath, 'utf8');
     }
 
     const context = github.context;


### PR DESCRIPTION
- Remove specific management of `GITHUB_WORKSPACE` content
- Github automatically runs commands in it 
- Allows to reference absolute path of files

Closes #176