### PR TITLE
feat: mode to delete comment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,15 @@ jobs:
           reactions: eyes, rocket
           mode: recreate
 
+      - name: Comment PR with message that will be deleted
+        uses: ./
+        with:
+          message: |
+            This PR is being built... 
+          comment_tag: nrt_message_delete
+          reactions: eyes
+          mode: delete
+
       - name: Comment PR with file
         uses: ./
         with:

--- a/action.yml
+++ b/action.yml
@@ -27,3 +27,4 @@ inputs:
 runs:
   using: 'node16'
   main: 'lib/index.js'
+  post: 'lib/cleanup/index.js'

--- a/lib/cleanup/index.js
+++ b/lib/cleanup/index.js
@@ -9507,7 +9507,7 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
-/***/ 399:
+/***/ 3812:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -9535,32 +9535,22 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const fs_1 = __importDefault(__nccwpck_require__(7147));
 const github = __importStar(__nccwpck_require__(5438));
 const core = __importStar(__nccwpck_require__(2186));
-// See https://docs.github.com/en/rest/reactions#reaction-types
-const REACTIONS = ['+1', '-1', 'laugh', 'confused', 'heart', 'hooray', 'rocket', 'eyes'];
 async function run() {
     try {
-        const message = core.getInput('message');
-        const filePath = core.getInput('filePath');
         const github_token = core.getInput('GITHUB_TOKEN');
         const pr_number = core.getInput('pr_number');
         const comment_tag = core.getInput('comment_tag');
-        const reactions = core.getInput('reactions');
         const mode = core.getInput('mode');
-        const create_if_not_exists = core.getInput('create_if_not_exists') === 'true';
-        if (!message && !filePath) {
-            core.setFailed('Either "filePath" or "message" should be provided as input');
+        if (mode !== 'delete') {
+            core.debug('This comment was not to be deleted. Skipping');
             return;
         }
-        let content = message;
-        if (!message && filePath) {
-            content = fs_1.default.readFileSync(filePath, 'utf8');
+        if (!comment_tag) {
+            core.debug("No 'comment_tag' parameter passed in. Cannot search for something to delete.");
+            return;
         }
         const context = github.context;
         const issue_number = parseInt(pr_number) || context.payload.pull_request?.number || context.payload.issue?.number;
@@ -9569,23 +9559,7 @@ async function run() {
             core.setFailed('No issue/pull request in input neither in current context.');
             return;
         }
-        async function addReactions(comment_id, reactions) {
-            const validReactions = reactions
-                .replace(/\s/g, '')
-                .split(',')
-                .filter((reaction) => REACTIONS.includes(reaction));
-            await Promise.allSettled(validReactions.map(async (content) => {
-                await octokit.rest.reactions.createForIssueComment({
-                    ...context.repo,
-                    comment_id,
-                    content,
-                });
-            }));
-        }
-        const comment_tag_pattern = comment_tag
-            ? `<!-- thollander/actions-comment-pull-request "${comment_tag}" -->`
-            : null;
-        const body = comment_tag_pattern ? `${content}\n${comment_tag_pattern}` : content;
+        const comment_tag_pattern = `<!-- thollander/actions-comment-pull-request "${comment_tag}" -->`;
         if (comment_tag_pattern) {
             let comment;
             for await (const { data: comments } of octokit.paginate.iterator(octokit.rest.issues.listComments, {
@@ -9597,50 +9571,15 @@ async function run() {
                     break;
             }
             if (comment) {
-                if (mode === 'upsert') {
-                    await octokit.rest.issues.updateComment({
-                        ...context.repo,
-                        comment_id: comment.id,
-                        body,
-                    });
-                    await addReactions(comment.id, reactions);
-                    return;
-                }
-                else if (mode === 'recreate') {
-                    await octokit.rest.issues.deleteComment({
-                        ...context.repo,
-                        comment_id: comment.id,
-                    });
-                    const { data: newComment } = await octokit.rest.issues.createComment({
-                        ...context.repo,
-                        issue_number,
-                        body,
-                    });
-                    await addReactions(newComment.id, reactions);
-                    return;
-                }
-                else if (mode === 'delete') {
-                    core.debug('Registering this comment to be deleted.');
-                }
-                else {
-                    core.setFailed(`Mode ${mode} is unknown. Please use 'upsert', 'recreate' or 'delete'.`);
-                    return;
-                }
-            }
-            else if (create_if_not_exists) {
-                core.info('No comment has been found with asked pattern. Creating a new comment.');
-            }
-            else {
-                core.info('Not creating comment as the pattern has not been found. Use `create_if_not_exists: true` to create a new comment anyway.');
+                core.info(`Deleting comment ${comment.id}.`);
+                await octokit.rest.issues.deleteComment({
+                    ...context.repo,
+                    comment_id: comment.id,
+                });
                 return;
             }
         }
-        const { data: comment } = await octokit.rest.issues.createComment({
-            ...context.repo,
-            issue_number,
-            body,
-        });
-        await addReactions(comment.id, reactions);
+        return;
     }
     catch (error) {
         if (error instanceof Error) {
@@ -9831,7 +9770,7 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(399);
+/******/ 	var __webpack_exports__ = __nccwpck_require__(3812);
 /******/ 	module.exports = __webpack_exports__;
 /******/ 	
 /******/ })()

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "GitHub action for commenting pull-request",
   "main": "lib/main.js",
   "scripts": {
-    "build": "ncc build src/main.ts -o lib",
+    "build": "npm run build:main && npm run build:cleanup",
+    "build:main": "ncc build src/main.ts -o lib",
+    "build:cleanup": "ncc build src/cleanup.ts -o lib/cleanup",
     "lint": "prettier --write **/*.ts"
   },
   "repository": {

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -1,0 +1,64 @@
+import * as github from '@actions/github';
+import * as core from '@actions/core';
+import { GetResponseDataTypeFromEndpointMethod } from '@octokit/types';
+
+async function run() {
+  try {
+    const github_token: string = core.getInput('GITHUB_TOKEN');
+    const pr_number: string = core.getInput('pr_number');
+    const comment_tag: string = core.getInput('comment_tag');
+    const mode: string = core.getInput('mode');
+
+    if (mode !== 'delete') {
+      core.debug('This comment was not to be deleted. Skipping');
+      return;
+    }
+
+    if (!comment_tag) {
+      core.debug("No 'comment_tag' parameter passed in. Cannot search for something to delete.");
+      return;
+    }
+
+    const context = github.context;
+    const issue_number = parseInt(pr_number) || context.payload.pull_request?.number || context.payload.issue?.number;
+
+    const octokit = github.getOctokit(github_token);
+
+    if (!issue_number) {
+      core.setFailed('No issue/pull request in input neither in current context.');
+      return;
+    }
+
+    const comment_tag_pattern = `<!-- thollander/actions-comment-pull-request "${comment_tag}" -->`;
+
+    if (comment_tag_pattern) {
+      type ListCommentsResponseDataType = GetResponseDataTypeFromEndpointMethod<
+        typeof octokit.rest.issues.listComments
+      >;
+      let comment: ListCommentsResponseDataType[0] | undefined;
+      for await (const { data: comments } of octokit.paginate.iterator(octokit.rest.issues.listComments, {
+        ...context.repo,
+        issue_number,
+      })) {
+        comment = comments.find((comment) => comment?.body?.includes(comment_tag_pattern));
+        if (comment) break;
+      }
+
+      if (comment) {
+        core.info(`Deleting comment ${comment.id}.`);
+        await octokit.rest.issues.deleteComment({
+          ...context.repo,
+          comment_id: comment.id,
+        });
+        return;
+      }
+    }
+    return;
+  } catch (error) {
+    if (error instanceof Error) {
+      core.setFailed(error.message);
+    }
+  }
+}
+
+run();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import fs from 'fs';
 import * as github from '@actions/github';
 import * as core from '@actions/core';
@@ -97,8 +96,10 @@ async function run() {
 
           await addReactions(newComment.id, reactions);
           return;
+        } else if (mode === 'delete') {
+          core.debug('Registering this comment to be deleted.')
         } else {
-          core.setFailed(`Mode ${mode} is unknown. Please use 'upsert' or 'recreate'.`);
+          core.setFailed(`Mode ${mode} is unknown. Please use 'upsert', 'recreate' or 'delete'.`);
           return;
         }
       } else if (create_if_not_exists) {


### PR DESCRIPTION
Add support for `delete` mode. 
It basically runs a post action that will check if a comment needs to be deleted at the end of the job. 
(docs: https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runspost)

Usage example : 

```
      - name: Comment PR with message that will be deleted
        uses: ./
        with:
          message: |
            This PR is being built... 
          comment_tag: nrt_message_delete
          reactions: eyes
          mode: delete
```

Closes #232