### PR TITLE
feat: add actions output variables

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
 
       - name: Comment PR with message
         uses: ./
+        id: nrt_message
         with:
           message: |
             Current branch is `${{ github.head_ref }}`.
@@ -54,6 +55,12 @@ jobs:
           message: Should not be printed
           comment_tag: nrt_create_if_not_exists
           create_if_not_exists: false
+
+      - name: Check outputs
+        run: |
+          echo "id : ${{ steps.nrt_message.outputs.id }}"
+          echo "body : ${{ steps.nrt_message.outputs.body }}"
+          echo "html_url : ${{ steps.nrt_message.outputs.html_url }}"
 
       - name: (AFTER) Setup test cases
         run: rm /tmp/foobar.txt

--- a/README.md
+++ b/README.md
@@ -125,6 +125,35 @@ This will delete the comment at the end of the job.
 | `mode` | Mode that will be used to update comment (upsert/recreate/delete) | | upsert |
 | `create_if_not_exists` | Whether a comment should be created even if `comment_tag` is not found | | true |
 
+
+## Outputs 
+
+### Action outputs
+
+You can get some outputs from this actions : 
+
+| Name | Description |
+| --- | --- |
+| `id` | Comment id that was created or updated | 
+| `body` | Comment body |
+| `html_url` | URL of the comment created or updated |
+
+## Example 
+
+```yaml
+- name: Comment PR
+  uses: thollander/actions-comment-pull-request@v2
+  id: hello
+  with:
+    message: |
+      Hello world ! :wave:
+- name: Check outputs
+  run: |
+    echo "id : ${{ steps.hello.outputs.id }}"
+    echo "body : ${{ steps.hello.outputs.body }}"
+    echo "html_url : ${{ steps.hello.outputs.html_url }}"
+```
+
 ## Permissions
 
 Depending on the permissions granted to your token, you may lack some rights. 

--- a/lib/index.js
+++ b/lib/index.js
@@ -9582,6 +9582,40 @@ async function run() {
                 });
             }));
         }
+        async function createComment({ owner, repo, issue_number, body, }) {
+            const { data: comment } = await octokit.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+            });
+            core.setOutput('id', comment.id);
+            core.setOutput('body', comment.body);
+            core.setOutput('html_url', comment.html_url);
+            await addReactions(comment.id, reactions);
+            return comment;
+        }
+        async function updateComment({ owner, repo, comment_id, body, }) {
+            const { data: comment } = await octokit.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id,
+                body,
+            });
+            core.setOutput('id', comment.id);
+            core.setOutput('body', comment.body);
+            core.setOutput('html_url', comment.html_url);
+            await addReactions(comment.id, reactions);
+            return comment;
+        }
+        async function deleteComment({ owner, repo, comment_id }) {
+            const { data: comment } = await octokit.rest.issues.deleteComment({
+                owner,
+                repo,
+                comment_id,
+            });
+            return comment;
+        }
         const comment_tag_pattern = comment_tag
             ? `<!-- thollander/actions-comment-pull-request "${comment_tag}" -->`
             : null;
@@ -9598,25 +9632,23 @@ async function run() {
             }
             if (comment) {
                 if (mode === 'upsert') {
-                    await octokit.rest.issues.updateComment({
+                    await updateComment({
                         ...context.repo,
                         comment_id: comment.id,
                         body,
                     });
-                    await addReactions(comment.id, reactions);
                     return;
                 }
                 else if (mode === 'recreate') {
-                    await octokit.rest.issues.deleteComment({
+                    await deleteComment({
                         ...context.repo,
                         comment_id: comment.id,
                     });
-                    const { data: newComment } = await octokit.rest.issues.createComment({
+                    await createComment({
                         ...context.repo,
                         issue_number,
                         body,
                     });
-                    await addReactions(newComment.id, reactions);
                     return;
                 }
                 else if (mode === 'delete') {
@@ -9635,12 +9667,11 @@ async function run() {
                 return;
             }
         }
-        const { data: comment } = await octokit.rest.issues.createComment({
+        await createComment({
             ...context.repo,
             issue_number,
             body,
         });
-        await addReactions(comment.id, reactions);
     }
     catch (error) {
         if (error instanceof Error) {


### PR DESCRIPTION
## Outputs 

### Action outputs

You can get some outputs from this actions : 

| Name | Description |
| --- | --- |
| `id` | Comment id that was created or updated | 
| `body` | Comment body |
| `html_url` | URL of the comment created or updated |

## Example 

```yaml
- name: Comment PR
  uses: thollander/actions-comment-pull-request@v2
  id: hello
  with:
    message: |
      Hello world ! :wave:
- name: Check outputs
  run: |
    echo "id : ${{ steps.hello.outputs.id }}"
    echo "body : ${{ steps.hello.outputs.body }}"
    echo "html_url : ${{ steps.hello.outputs.html_url }}"
```

Closes #284