### PR TITLE
Add only-delete option

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,10 @@ _That is particularly interesting while committing multiple times in a PR and th
 
 Note: the input `mode` can be used to either `upsert` (by default) or `recreate` the comment (= delete and create)
 
-### Delete a comment
+### Delete a comment on cleanup
 
-Deleting an existing comment is also possible thanks to the `comment_tag` input combined with `mode: delete`.
-
-This will delete the comment at the end of the job. 
+Deleting a comment upon job completion is possible with the `mode: delete` flag.
+The comment will be created initially, and on cleanup, it will be deleted.
 
 ```yml
 ...
@@ -110,7 +109,29 @@ This will delete the comment at the end of the job.
 
 ```
 
-## Inputs 
+### Delete a comment
+
+Deleting a comment with a specific `comment_tag` is possible with the
+`mode: only-delete` flag. If a comment with the `comment_tag` exists, it will
+be deleted when ran.
+
+```yml
+...
+- name: Create a comment
+  uses: thollander/actions-comment-pull-request@v2
+  with:
+    message: Example comment
+    comment_tag: to_delete
+
+- name: Delete the comment
+  uses: thollander/actions-comment-pull-request@v2
+  with:
+    comment_tag: to_delete
+    mode: only-delete
+
+```
+
+## Inputs
 
 ### Action inputs
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -9554,8 +9554,8 @@ async function run() {
         const reactions = core.getInput('reactions');
         const mode = core.getInput('mode');
         const create_if_not_exists = core.getInput('create_if_not_exists') === 'true';
-        if (!message && !filePath) {
-            core.setFailed('Either "filePath" or "message" should be provided as input');
+        if (!message && !filePath && mode !== 'only-delete') {
+            core.setFailed('Either "filePath" or "message" should be provided as input unless running as "only-delete".');
             return;
         }
         let content = message;
@@ -9651,13 +9651,24 @@ async function run() {
                     });
                     return;
                 }
+                else if (mode === 'only-delete') {
+                    await deleteComment({
+                        ...context.repo,
+                        comment_id: comment.id,
+                    });
+                    return;
+                }
                 else if (mode === 'delete') {
                     core.debug('Registering this comment to be deleted.');
                 }
                 else {
-                    core.setFailed(`Mode ${mode} is unknown. Please use 'upsert', 'recreate' or 'delete'.`);
+                    core.setFailed(`Mode ${mode} is unknown. Please use 'upsert', 'recreate', 'delete', or 'only-delete'.`);
                     return;
                 }
+            }
+            else if (mode === 'only-delete') {
+                core.info('No comment has been found with asked pattern. Nothing to delete.');
+                return;
             }
             else if (create_if_not_exists) {
                 core.info('No comment has been found with asked pattern. Creating a new comment.');

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,8 +18,8 @@ async function run() {
     const mode: string = core.getInput('mode');
     const create_if_not_exists: boolean = core.getInput('create_if_not_exists') === 'true';
 
-    if (!message && !filePath) {
-      core.setFailed('Either "filePath" or "message" should be provided as input');
+    if (!message && !filePath && mode !== 'only-delete') {
+      core.setFailed('Either "filePath" or "message" should be provided as input unless running as "only-delete".');
       return;
     }
 
@@ -157,12 +157,21 @@ async function run() {
             body,
           });
           return;
+        } else if (mode === 'only-delete') {
+          await deleteComment({
+            ...context.repo,
+            comment_id: comment.id,
+          });
+          return;
         } else if (mode === 'delete') {
           core.debug('Registering this comment to be deleted.');
         } else {
-          core.setFailed(`Mode ${mode} is unknown. Please use 'upsert', 'recreate' or 'delete'.`);
+          core.setFailed(`Mode ${mode} is unknown. Please use 'upsert', 'recreate', 'delete', or 'only-delete'.`);
           return;
         }
+      } else if (mode === 'only-delete') {
+        core.info('No comment has been found with asked pattern. Nothing to delete.');
+        return;
       } else if (create_if_not_exists) {
         core.info('No comment has been found with asked pattern. Creating a new comment.');
       } else {


### PR DESCRIPTION
At a glance, I expected the `mode: delete` option to just delete a comment. 
Instead, the `delete` mode deletes comments during cleanup.

This adds functionality to delete comments immediately. In order to be 
backward compatible, I left the `delete` mode unchanged. I added
an `only-delete` mode which just deletes comments immediately.

Ref: https://github.com/thollander/actions-comment-pull-request/issues/361

cc @liamnichols 