### PR TITLE
fix: Allow reactions to be added to an existing comment without providing a `message`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -93,12 +93,15 @@ async function run() {
       comment_id: number;
       body: string;
     }) {
-      const { data: comment } = await octokit.rest.issues.updateComment({
+      const params = {
         owner,
         repo,
         comment_id,
-        body,
-      });
+      };
+
+      const { data: comment } = await (body
+        ? octokit.rest.issues.updateComment({ ...params, body })
+        : octokit.rest.issues.getComment(params));
 
       core.setOutput('id', comment.id);
       core.setOutput('body', comment.body);


### PR DESCRIPTION
This allows users to add reactions to an existing comment without having to provide a `message` input. At the moment, trying to do this will fail because the API call to `issues.updateComment` fails if no `body` (message) param is provided.

This should allow things like this to work:

```yaml
- uses: thollander/actions-comment-pull-request@v1
  with:
    comment_tag: foo
    reactions: eyes
```